### PR TITLE
fix homepage_url

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,5 +6,5 @@
 	"name": "Math Mode",
 	"description": "Turn your notes into a powerful calculator with inline math.",
 	"author": "Caleb John",
-	"homepage_url": "github.com/CalebJohn/joplin-math-mode"
+	"homepage_url": "https://github.com/CalebJohn/joplin-math-mode"
 }


### PR DESCRIPTION
The URL must start with https:// or http:// otherwise a relative URL is generated, which is not valid.
This is also one of the reasons, why clicking on the `Math Mode` title in `Config > Plugins` does not
open the web page.
The README.md in the plugins repo also has the wrong (realtive) link that resukts in a 404.