### PR TITLE
Fix a typo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ Another `total` example that demonstrates the explicit addition and summation sy
 
 ## Euro Trip
 Example that demonstrates the use of currency conversion. Also uses the `total` variable to sum up the daily cost of a trip.
-![example of foreign trip planning]('./euro_trip.png)
+![example of foreign trip planning](./euro_trip.png)
 
 
 # Advanced


### PR DESCRIPTION
The typo prevent the display of the euro_trip.png image in the page https://github.com/CalebJohn/joplin-math-mode/tree/main/examples.